### PR TITLE
Session reference on Providers and base models

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -50,6 +50,7 @@ type Role interface {
 
 type RoleProviderAllRoles func(roleProvider RoleProvider, p Profile, r Resource) []Role
 type RoleProviderBestRole func(ropeProvider RoleProvider, p Profile, r Resource) Role
+
 //RoleProvider provides an interface to ask what role or roles a Profile and Resource matching would have
 type RoleProvider interface {
 	HandledProfileName() string
@@ -58,6 +59,8 @@ type RoleProvider interface {
 	SetAllRoles(roleProviderAllRoles RoleProviderAllRoles)
 	BestRole(p Profile, r Resource) Role
 	SetBestRole(roleProviderBestRole RoleProviderBestRole)
+	SetSession(sess Session)
+	Session() Session
 }
 
 //Permission represents the answer to "Does Role with Resource have this `permission`?"
@@ -72,9 +75,12 @@ type Permission interface {
 }
 
 type PermissionProviderGetPermission func(permissionProvider PermissionProvider, role Role, permission string) Permission
+
 //PermissionProvider
 type PermissionProvider interface {
 	HandledResourceName() string
 	GetPermission(role Role, permission string) Permission
 	SetGetPermission(getPermission PermissionProviderGetPermission)
+	SetSession(sess Session)
+	Session() Session
 }

--- a/models/permission_provider.go
+++ b/models/permission_provider.go
@@ -5,8 +5,9 @@ import (
 )
 
 type PermissionProvider struct {
-	resourceName string
+	resourceName  string
 	getPermission perm.PermissionProviderGetPermission
+	session       perm.Session
 }
 
 func NewPermissionProvider(resourceName string) *PermissionProvider {
@@ -26,6 +27,14 @@ func (pp *PermissionProvider) GetPermission(role perm.Role, permission string) p
 
 func (pp *PermissionProvider) SetGetPermission(permissionProviderGetPermission perm.PermissionProviderGetPermission) {
 	pp.getPermission = permissionProviderGetPermission
+}
+
+func (pp *PermissionProvider) SetSession(sess perm.Session) {
+	pp.session = sess
+}
+
+func (pp PermissionProvider) Session() perm.Session {
+	return pp.session
 }
 
 func getPermission(permissionProvider perm.PermissionProvider, role perm.Role, permission string) perm.Permission {

--- a/models/role_provider.go
+++ b/models/role_provider.go
@@ -9,8 +9,9 @@ import (
 type RoleProvider struct {
 	handledProfileName  string
 	handledResourceName string
-	allRoles perm.RoleProviderAllRoles
-	bestRole perm.RoleProviderBestRole
+	allRoles            perm.RoleProviderAllRoles
+	bestRole            perm.RoleProviderBestRole
+	session             perm.Session
 }
 
 //NewRoleProvider create a new RoleProvider that handles Profile and Resource by name
@@ -43,7 +44,7 @@ func (rp *RoleProvider) BestRole(p perm.Profile, r perm.Resource) perm.Role {
 	return rp.bestRole(rp, p, r)
 }
 
-func bestRole(roleProvider perm.RoleProvider, p perm.Profile, r perm.Resource, ) perm.Role {
+func bestRole(roleProvider perm.RoleProvider, p perm.Profile, r perm.Resource) perm.Role {
 	roles := roleProvider.AllRoles(p, r)
 	return bestRoleWithRoles(roleProvider, p, r, roles)
 }
@@ -73,4 +74,14 @@ func (rp *RoleProvider) HandledResourceName() string {
 //String makes a pretty string
 func (rp RoleProvider) String() string {
 	return fmt.Sprintf("RoleProvider[%s][%s]", rp.handledProfileName, rp.handledResourceName)
+}
+
+//SetSession sets the Session on this RoleProvider
+func (rp *RoleProvider) SetSession(sess perm.Session) {
+	rp.session = sess
+}
+
+//Session returns the Session this RoleProvider was initialized with
+func (rp RoleProvider) Session() perm.Session {
+	return rp.session
 }

--- a/session.go
+++ b/session.go
@@ -60,6 +60,7 @@ func (s *session) RegisterRoleProvider(roleProvider RoleProvider) error {
 	if rp != nil {
 		return errors.New("Cannot register duplicate RoleProvider")
 	}
+	roleProvider.SetSession(s)
 	s.roleProviders = append(s.roleProviders, roleProvider)
 	return nil
 }
@@ -86,6 +87,7 @@ func (s *session) RegisterPermissionProvider(permissionProvider PermissionProvid
 	if pp != nil {
 		return errors.New("Cannot register duplicate PermissionProvider")
 	}
+	permissionProvider.SetSession(s)
 	s.permissionProviders = append(s.permissionProviders, permissionProvider)
 	return nil
 }


### PR DESCRIPTION
Implemented including a reference to the Session a Role/Permission provider is registered to. Allowing recursive lookups from within a provider implementation.

closes #5 
