### PR TITLE
Session context and parent 

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -23,6 +23,13 @@ type Session interface {
 	DefaultRole(profile Profile, resource Resource) Role
 	GetRole(p Profile, r Resource) Role
 	GetPermission(p Profile, r Resource, permission string) Permission
+
+	SetContext(context interface{})
+	Context() interface{}
+
+	NewSession(name string) Session
+	SetParent(sess Session)
+	Parent() Session
 }
 
 //Profile interface represents a requesting user, group, organizational unit, etc.
@@ -50,6 +57,7 @@ type Role interface {
 
 type RoleProviderAllRoles func(roleProvider RoleProvider, p Profile, r Resource) []Role
 type RoleProviderBestRole func(ropeProvider RoleProvider, p Profile, r Resource) Role
+
 //RoleProvider provides an interface to ask what role or roles a Profile and Resource matching would have
 type RoleProvider interface {
 	HandledProfileName() string
@@ -72,6 +80,7 @@ type Permission interface {
 }
 
 type PermissionProviderGetPermission func(permissionProvider PermissionProvider, role Role, permission string) Permission
+
 //PermissionProvider
 type PermissionProvider interface {
 	HandledResourceName() string

--- a/session.go
+++ b/session.go
@@ -74,6 +74,9 @@ func (s session) RoleProviderFor(profileName string, resourceName string) RolePr
 			return s.roleProviders[i]
 		}
 	}
+	if s.parent != nil {
+		return s.parent.RoleProviderFor(profileName, resourceName)
+	}
 	return nil
 }
 
@@ -98,6 +101,9 @@ func (s session) PermissionProviderFor(resourceName string) PermissionProvider {
 		if s.permissionProviders[i].HandledResourceName() == resourceName {
 			return s.permissionProviders[i]
 		}
+	}
+	if s.parent != nil {
+		return s.parent.PermissionProviderFor(resourceName)
 	}
 	return nil
 }

--- a/session.go
+++ b/session.go
@@ -14,6 +14,8 @@ type session struct {
 	permissionProviders []PermissionProvider // Registered PermissionProviders
 	defaultRoleFunc     DefaultRoleFunc      // Function that can resolve a default role
 	logger              *log.Logger          // Logger to use for errors/warnings/info
+	ctx                 interface{}          // A user assigned context for this session
+	parent              Session              // if not nil, this is the parent Session
 }
 
 type DefaultRoleFunc func(session Session, profile Profile, resource Resource) Role
@@ -130,6 +132,33 @@ func (s session) GetPermission(profile Profile, resource Resource, permission st
 		return nil
 	}
 	return permissionProvider.GetPermission(role, permission)
+}
+
+// SetContext for this Session
+func (s *session) SetContext(context interface{}) {
+	s.ctx = context
+}
+
+// Context get the context assigned to this Session
+func (s session) Context() interface{} {
+	return s.ctx
+}
+
+// NewSession as a child of this Session
+func (s *session) NewSession(name string) Session {
+	child := newSession(name)
+	child.SetParent(s)
+	return child
+}
+
+// SetParent of this Session
+func (s *session) SetParent(sess Session) {
+	s.parent = sess
+}
+
+// Parent of this Session
+func (s session) Parent() Session {
+	return s.parent
 }
 
 var sessions = map[string]Session{} //Singleton registry of Sessions

--- a/session_test.go
+++ b/session_test.go
@@ -194,6 +194,21 @@ func TestSession(t *testing.T) {
 				rpdup := &mockRoleProvider{"User", "Post"}
 				So(s.RegisterRoleProvider(rpdup), ShouldNotBeNil)
 			})
+
+			Convey("With Child", func() {
+				child := s.NewSession("child")
+				rp2 := &mockRoleProvider{"User", "Comment"}
+				child.RegisterRoleProvider(rp2)
+				Convey("Looks at child level", func() {
+					r := child.RoleProviderFor("User", "Comment")
+					So(r, ShouldEqual, rp2)
+				})
+				Convey("It recurses to the parent", func() {
+					r := child.RoleProviderFor("User", "Post")
+					So(r, ShouldEqual, rp)
+				})
+
+			})
 		})
 
 		Convey("RegisterPermissionProvider", func() {
@@ -214,6 +229,21 @@ func TestSession(t *testing.T) {
 			Convey("Error on double registration", func() {
 				ppdup := &mockPermissionProvider{"Post"}
 				So(s.RegisterPermissionProvider(ppdup), ShouldNotBeNil)
+			})
+
+			Convey("With Child", func() {
+				child := s.NewSession("child")
+				pp2 := &mockPermissionProvider{"Comment"}
+				child.RegisterPermissionProvider(pp2)
+				Convey("Looks at child level", func() {
+					r := child.PermissionProviderFor("Comment")
+					So(r, ShouldEqual, pp2)
+				})
+				Convey("It recurses to the parent", func() {
+					r := child.PermissionProviderFor("Post")
+					So(r, ShouldEqual, pp)
+				})
+
 			})
 		})
 

--- a/session_test.go
+++ b/session_test.go
@@ -24,7 +24,7 @@ func (rp mockRoleProvider) AllRoles(p Profile, r Resource) []Role {
 	return []Role{&mockRole{"guest", p, r, rp}}
 }
 func (rp mockRoleProvider) SetAllRoles(roleProviderAllRoles RoleProviderAllRoles) {
-	
+
 }
 func (rp mockRoleProvider) BestRole(p Profile, r Resource) Role {
 	return &mockRole{"guest", p, r, rp}
@@ -160,6 +160,19 @@ func TestSession(t *testing.T) {
 
 		Convey("Implements Session", func() {
 			So(s, ShouldImplement, (*Session)(nil))
+		})
+
+		Convey("Context", func() {
+			ctx := map[string]interface{}{"cat": "awesome", "dog": "nice"}
+			Convey("Sets Context", func() {
+				s.SetContext(ctx)
+				So(s.Context(), ShouldEqual, ctx)
+			})
+		})
+
+		Convey("Parent", func() {
+			child := s.NewSession("child")
+			So(child.Parent(), ShouldEqual, s)
 		})
 
 		Convey("RegisterRoleProvider", func() {


### PR DESCRIPTION
This allows a interface{} context to be associated to a Session, to be used how ever the implementer wants. Typically  Request Context to pass along any interesting information.

Implemented a Parent relationship, so a Session can recurse down a chain to resolve permission related requests.

closes #4 
